### PR TITLE
use yaml.safe_load

### DIFF
--- a/cam_supervisor.py
+++ b/cam_supervisor.py
@@ -74,7 +74,7 @@ def get_yaml(address: str, auth: tuple) -> dict:
 
     if r.status_code == 200:
         logging.info("Successfully retrieved config yaml!")
-        return yaml.load(r.text, Loader=yaml.CLoader)
+        return yaml.safe_load(r.text)
     else:
         logging.warning("Could not get config yaml!")
         return None


### PR DESCRIPTION
We should use safe_load, because it is sufficient but safer (especially since we fetch the config from a remote resource).

See e.g. https://pyyaml.docsforge.com/master/api/yaml/safe_load/