### PR TITLE
use config file for service configuration and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,16 +129,20 @@ infrastructure:
 
 ### Configure The Service
 
-You need to set the following variables in `cam_supervisor.py`:
+You need to set the following variables in `service_configuration.yml`:
 
 variable | example value | description
 ---|---|---
-`YAML_ADDRESS` | `"https://bbb-cam-config.example.com/config.yml"` | the url of the config file
-`YAML_AUTH` | `("your-user", "your-password")` | a tuple with the credentials for the basic auth of the config location
-`HOSTNAME` | `"bbb-cam.example.com"` | the name of the current instance, needed to look up the scheduled streams
+`schedule_url` | `"https://bbb-cam-config.example.com/config.yml"` | the url of the config file
+`schedule_basic_auth_user` | `"your-user"` | the user for the credentials for the basic auth of the config location
+`schedule_basic_auth_password` | `"your-password"` | the password for the credentials for the basic auth of the config location
+`schedule_instance_key` | `"bbb-cam.example.com"` | the name of the current instance, needed to look up the scheduled streams
 
 Then start the system by running (from inside the virtual environment):
 
 ```
 python3 cam_supervisor.py
 ```
+
+You can also specify the location of the config file with the `--config` command line option
+and the path of a local schedule config for testing with the `--test-schedules` option.

--- a/service_configuration.yml
+++ b/service_configuration.yml
@@ -1,0 +1,5 @@
+---
+schedule_url: "https://bbb-cam-config.example.com/config.yml"
+schedule_basic_auth_user: ""
+schedule_basic_auth_password: ""
+schedule_instance_key: ""

--- a/test_config.yml
+++ b/test_config.yml
@@ -1,0 +1,36 @@
+---
+clients:
+  # Instance 1, needs to be the same as 'HOSTNAME' in service config below
+  bbb-cam01.example.com:
+    schedule:
+      - audio: "rtsp://camera1.exmple.de/stream"
+        id: camera1
+        location: "<YOUR-STUDIP-MEETING-LINK>"
+        start: "2022-12-1T15:00:00+0100"
+        stop: 2022-12-1T16:00:00+0100
+        video: "rtsp://camera1.exmple.de/stream"
+      - audio: "rtsp://camera1.exmple.de/stream"
+        id: camera1
+        location: "<YOUR-GREENLIGHT-MEETING-LINK>"
+        start: "2022-1-31T15:00:00+0100"
+        stop: 2022-1-31T16:00:00+0100
+        video: "rtsp://camera1.exmple.de/stream"
+  # Instance 2, needs to be the same as 'HOSTNAME' in service config below
+  bbb-cam02.example.com:
+    schedule:
+      - audio: ""  # no audio stream
+        id: camera2-without-audio
+        location: "<YOUR-STUDIP-MEETING-LINK>"
+        start: 2022-11-9T14:30:00+0100
+        stop: 2022-11-9T16:00:00+0100
+        video: "rtsp://camera2.exmple.de/stream"
+      - audio: "rtsp://camera3.exmple.de/stream"
+        id: camera3-with-audio
+        location: "<YOUR-GREENLIGHT-MEETING-LINK>"
+        start: 2022-11-9T14:30:00+0100
+        stop: 2022-11-9T16:00:00+0100
+        video: "rtsp://camera3.exmple.de/stream"
+
+infrastructure:
+  greenlight.example.de: greenlight
+  studip.example.de: studip


### PR DESCRIPTION
This commit introduces a config file for the service configuration and also puts the test schedules in a separate file. It also adds two command line parameter to make the paths adjustable and updates the docs.

Closes #38